### PR TITLE
feat: Fixed the case where CCTV5+ would be recognized as CCTV5 when using URL API requests.

### DIFF
--- a/epg/index.php
+++ b/epg/index.php
@@ -22,7 +22,7 @@ if (substr_count($requestUrl, '?') > 1) {
 }
 
 // 解析 URL 中的查询参数
-parse_str(parse_url($requestUrl, PHP_URL_QUERY), $query_params);
+parse_str(str_replace('+', '%2B', parse_url($requestUrl, PHP_URL_QUERY)), $query_params);
 
 // 获取 URL 中的 token 参数并验证
 $tokenRange = $Config['token_range'] ?? 1;


### PR DESCRIPTION
Fixed the case where CCTV5+ would be recognized as CCTV5 when using URL API requests.

![Snipaste_2025-02-08_12-34-07](https://github.com/user-attachments/assets/b9410e39-5adc-43f2-ad6c-bfb794b34a32)

![Snipaste_2025-02-08_12-35-00](https://github.com/user-attachments/assets/65729f2b-c5c7-4c92-a2cf-7a3ddb395cad)
