### PR TITLE
perf: Add redis support

### DIFF
--- a/epg/public.php
+++ b/epg/public.php
@@ -55,6 +55,13 @@ try {
     exit();
 }
 
+/*
+Redis 缓存密码，默认不启用，除非需要设置密码。
+$Config = [
+    'redis_password' => 'your_redis_password', // 替换为你的 Redis 密码
+];
+ */
+
 // 初始化数据库表
 function initialDB() {
     global $db;


### PR DESCRIPTION
添加Redis支持，并兼容之前版本，即使Redis或memcached没有被正常安装或者容器出错，也不影响脚本继续执行。

添加最常用的缓存Redis，提高效率。

美中不足的一点是没改manage.php，可以增加一个字段来设置Redis密码，现在是在Public.php 58行设置了Redis缓存密码，需要用户手动配置。