### PR TITLE
fix: 修复 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,15 +180,15 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtow
 <picture>
   <source
     media="(prefers-color-scheme: dark)"
-    srcset="https://api.star-history.com/svg?repos=taksssss/iptv-tool&type=Date&theme=dark"
+    srcset="https://star-history.dera.page/svg?repos=taksssss/iptv-tool&type=Date&theme=dark"
   />
   <source
     media="(prefers-color-scheme: light)"
-    srcset="https://api.star-history.com/svg?repos=taksssss/iptv-tool&type=Date"
+    srcset="https://star-history.dera.page/svg?repos=taksssss/iptv-tool&type=Date"
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=taksssss/iptv-tool&type=Date"
+    src="https://star-history.dera.page/svg?repos=taksssss/iptv-tool&type=Date"
   />
 </picture>
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub 星标接口限制已无法正常显示。本次更新切换到新的数据源，无需 API token，图表即可恢复正常展示。